### PR TITLE
Switched express server launch to use grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,6 +76,16 @@ module.exports = function (grunt) {
     },
 
 
+    express: {
+      options: {},
+      web: {
+        options: {
+          script: './server.js',
+        }
+      },
+    },
+
+
     /***************************************************************************************************
     *
     *  Watching tasks
@@ -113,10 +123,21 @@ module.exports = function (grunt) {
       livereload: {
         options: {},
         files: [
-          '<%= server.app %>/**/*.html',
-          'dist/styles/*.css',
-          '<%= server.app %>/images/**/*.{png,jpg,jpeg,gif,webp,svg}'
+          '<%= server.dist %>/**/*',
         ]
+      },
+      web: {
+        files: [
+          'api/**/*.js',
+          'server.js',
+        ],
+        tasks: [
+          'express:web'
+        ],
+        options: {
+          nospawn: true,
+          atBegin: true,
+        }
       }
     },
 
@@ -415,35 +436,6 @@ module.exports = function (grunt) {
 
     /***************************************************************************************************
     *
-    *  Concurrency tasks
-    *
-    ****************************************************************************************************/
-
-    concurrent: {
-      serverDev : {
-        tasks : [
-          'watch',
-          'shell:serve'
-        ],
-        options: {
-          logConcurrentOutput: true
-        }
-      },
-      serverProd : {
-        tasks : [
-          'watch',
-          'shell:serveProd'
-        ],
-        options: {
-          logConcurrentOutput: true
-        }
-      }
-    },
-
-
-
-    /***************************************************************************************************
-    *
     *  shell tasks
     *
     ****************************************************************************************************/
@@ -462,13 +454,13 @@ module.exports = function (grunt) {
         }
       },
       serve: {
-        command: 'nodemon server.js -q --ignore "test/" --ignore "app/" --ignore "dist/"',
+        command: 'node server.js -q --ignore "test/" --ignore "app/" --ignore "dist/"',
         options: {
           async: false
         }
       },
       serveProd: {
-        command: 'NODE_ENV=production nodemon server.js -q --ignore "test/" --ignore "app/" --ignore "dist/"',
+        command: 'NODE_ENV=production node server.js -q --ignore "test/" --ignore "app/" --ignore "dist/"',
         options: {
           async: false
         }
@@ -500,13 +492,13 @@ module.exports = function (grunt) {
     if (prod) {
       grunt.task.run([
         'build-prod',
-        'concurrent:serverProd'
+        'watch'
       ]);
 
     } else {
       grunt.task.run([
         'build-dev',
-        'concurrent:serverDev'
+        'watch'
       ]);
     }
   });

--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ General
    - `--prod` builds a production version (minified)
    - `--dev` builds a dev version (unminified/default)
 
-If you get an `addr in use` error, run `killall node` to terminate active node servers
-
 ## Useful grunt commands
 
 `grunt serve` -> run with the current build (no watch)

--- a/app/components/home/home.scss
+++ b/app/components/home/home.scss
@@ -125,6 +125,10 @@
           cursor: pointer;
           color: $text-color;
 
+          &.view-more {
+            text-align: center;
+          }
+
           .leading {
             flex:1;
             padding: 0 $space;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "scripts":  {
+  "scripts": {
     "start": "node server",
     "test": "mocha 'test/**/*.js'"
   },
@@ -38,6 +38,7 @@
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.4.0",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-express-server": "^0.4.19",
     "grunt-filerev": "^0.2.1",
     "grunt-google-cdn": "^0.4.0",
     "grunt-mocha": "^0.4.11",


### PR DESCRIPTION
@DuaneGarber we no longer use nodemon, instead the grunt-express module . This will keep servers from living past the termination of the grunt script (not sure if you've noticed this)